### PR TITLE
fix: move from serialport/node-serialport

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
-# Typescript Library Template
+# @serialport/binding-mock
 
-[![Release](https://github.com/reconbot/typescript-library-template/actions/workflows/test.yml/badge.svg)](https://github.com/reconbot/typescript-library-template/actions/workflows/test.yml)
+```ts
+import { MockBinding } from '@serialport/binding-mock'
+const MockBinding = new MockBinding()
 
-This is an example project for shipping typescript using the rules layed out by [@southpolesteve](https://twitter.com/southpolesteve) in his ["Shipping Typescript to NPM"](https://speakerdeck.com/southpolesteve/shipping-typescript-to-npm?slide=10) talk that he gave at NYC typescript.
-
-It gives you a library in UMD and ESM that's rolled up with rollup and includes rolled up types. It makes browser users, node users and me very happy.
-
-Also includes eslint, mocha, semantic-release and github actions.  Now updated to include the exports directive in the package.json.
-
-## Guide
-
-- Set the repo secret `NPM_TOKEN` before your first push so that you can publish to npm.
-- Change all references in package.json to your own project name
-- If you want external dependencies, add them to the `external` section in the `rollup.config.js` otherwise they will be bundled in the library.
+MockBinding.createPort('/dev/fakePort', { echo: true })
+await MockBinding.write(Buffer.from('data')))
+```

--- a/lib/foo-test.ts
+++ b/lib/foo-test.ts
@@ -1,8 +1,0 @@
-import { assert } from 'chai'
-import { foo } from './foo'
-
-describe('foo', () => {
-  it('loads', () => {
-    assert.equal(foo, 'foo')
-  })
-})

--- a/lib/foo.ts
+++ b/lib/foo.ts
@@ -1,1 +1,0 @@
-export const foo = 'foo'

--- a/lib/index-test.ts
+++ b/lib/index-test.ts
@@ -1,0 +1,92 @@
+import { MockBinding } from '.'
+import { OpenOptions } from '@serialport/bindings-interface'
+import { assert } from 'chai'
+
+export const shouldReject = async (promise: Promise<unknown>, errType = Error, message = 'Should have rejected') => {
+  try {
+    await promise
+  } catch (err) {
+    assert.instanceOf(err, errType)
+    return err
+  }
+  throw new Error(message)
+}
+
+const openOptions: OpenOptions = {
+  path: '/dev/exists',
+  baudRate: 9600,
+  dataBits: 8,
+  lock: false,
+  stopBits: 1,
+  parity: 'none',
+  rtscts: false,
+  xon: false,
+  xoff: false,
+  xany: false,
+  hupcl: false,
+}
+
+describe('MockBinding', () => {
+  afterEach(() => {
+    MockBinding.reset()
+  })
+
+  describe('instance method', () => {
+    describe('open', () => {
+      describe('when phony port not created', () => {
+        it('should reject', async () => {
+          await shouldReject(MockBinding.open(openOptions))
+        })
+      })
+
+      describe('when phony port created', () => {
+        beforeEach(() => {
+          MockBinding.createPort('/dev/exists')
+        })
+
+        it('should open the phony port', async () => {
+          const port = await MockBinding.open(openOptions)
+          assert.isTrue(port.isOpen)
+        })
+
+        it('should have a "port" prop with "info.serialNumber" prop', async () => {
+          const port = await MockBinding.open(openOptions)
+          assert.strictEqual(port.port.info.serialNumber, '1')
+        })
+      })
+    })
+  })
+
+  describe('static method', () => {
+    describe('createPort', () => {
+      it('should increment the serialNumber', async () => {
+        MockBinding.createPort('/dev/exists')
+        MockBinding.createPort('/dev/ttyUSB1')
+        const port1 = await MockBinding.open(openOptions)
+        const port2 = await MockBinding.open({ ...openOptions, path: '/dev/ttyUSB1' })
+        assert.strictEqual(port1.port.info.serialNumber, '1')
+        assert.strictEqual(port2.port.info.serialNumber, '2')
+      })
+    })
+    describe('reset', () => {
+      beforeEach(async () => {
+        MockBinding.createPort('/dev/exists')
+        const port = await MockBinding.open(openOptions)
+        assert.strictEqual(port.port?.info.serialNumber, '1')
+        await port.close()
+      })
+
+      it('should delete any configured phony ports', async () => {
+        MockBinding.reset()
+        await shouldReject(MockBinding.open(openOptions))
+      })
+
+      it('should reset the serialNumber assigned to the phony port', async () => {
+        MockBinding.reset()
+        MockBinding.createPort('/dev/exists')
+        const port = await MockBinding.open(openOptions)
+        assert.strictEqual(port.port.info.serialNumber, '1')
+      })
+    })
+  })
+})

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,373 @@
-export { foo } from './foo'
+import debugFactory from 'debug'
+import { BindingInterface, BindingPortInterface, PortStatus, SetOptions, UpdateOptions, OpenOptions, PortInfo } from '@serialport/bindings-interface'
+const debug = debugFactory('serialport/binding-mock')
+
+export interface MockPortInternal {
+  data: Buffer
+  echo: boolean
+  record: boolean
+  info: PortInfo
+  maxReadSize: number
+  readyData?: Buffer
+  openOpt?: OpenOptions
+}
+
+export interface CreatePortOptions {
+  echo?: boolean
+  record?: boolean
+  readyData?: Buffer
+  maxReadSize?: number
+  manufacturer?: string
+  vendorId?: string
+  productId?: string
+}
+
+let ports: {
+  [key: string]: MockPortInternal
+} = {}
+let serialNumber = 0
+
+function resolveNextTick() {
+  return new Promise<void>(resolve => process.nextTick(() => resolve()))
+}
+
+export class CanceledError extends Error {
+  canceled: true
+  constructor(message: string) {
+    super(message)
+    this.canceled = true
+  }
+}
+
+export interface MockBindingInterface extends BindingInterface<MockPortBinding> {
+  reset(): void
+  createPort(path: string, opt?: CreatePortOptions): void
+}
+
+export const MockBinding: MockBindingInterface = {
+  reset() {
+    ports = {}
+    serialNumber = 0
+  },
+
+  // Create a mock port
+  createPort(path: string, options: CreatePortOptions = {}) {
+    serialNumber++
+    const optWithDefaults = {
+      echo: false,
+      record: false,
+      manufacturer: 'The J5 Robotics Company',
+      vendorId: undefined,
+      productId: undefined,
+      maxReadSize: 1024,
+      ...options,
+    }
+
+    ports[path] = {
+      data: Buffer.alloc(0),
+      echo: optWithDefaults.echo,
+      record: optWithDefaults.record,
+      readyData: optWithDefaults.readyData,
+      maxReadSize: optWithDefaults.maxReadSize,
+      info: {
+        path,
+        manufacturer: optWithDefaults.manufacturer,
+        serialNumber: `${serialNumber}`,
+        pnpId: undefined,
+        locationId: undefined,
+        vendorId: optWithDefaults.vendorId,
+        productId: optWithDefaults.productId,
+      },
+    }
+    debug(serialNumber, 'created port', JSON.stringify({ path, opt: options }))
+  },
+
+  async list() {
+    debug(null, 'list')
+    return Object.values(ports).map(port => port.info)
+  },
+
+  async open(options) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      throw new TypeError('"options" is not an object')
+    }
+
+    if (!options.path) {
+      throw new TypeError('"path" is not a valid port')
+    }
+
+    if (!options.baudRate) {
+      throw new TypeError('"baudRate" is not a valid baudRate')
+    }
+
+    const openOptions: Required<OpenOptions> = {
+      dataBits: 8,
+      lock: true,
+      stopBits: 1,
+      parity: 'none',
+      rtscts: false,
+      xon: false,
+      xoff: false,
+      xany: false,
+      hupcl: true,
+      ...options,
+    }
+    const { path } = openOptions
+
+    debug(null, `open: opening path ${path}`)
+
+    const port = ports[path]
+    await resolveNextTick()
+    if (!port) {
+      throw new Error(`Port does not exist - please call MockBinding.createPort('${path}') first`)
+    }
+
+    const serialNumber = port.info.serialNumber
+
+    if (port.openOpt?.lock) {
+      debug(serialNumber, 'open: Port is locked cannot open')
+      throw new Error('Port is locked cannot open')
+    }
+
+    debug(serialNumber, `open: opened path ${path}`)
+
+    port.openOpt = { ...openOptions }
+
+    return new MockPortBinding(port, openOptions)
+  },
+}
+
+/**
+ * Mock bindings for pretend serialport access
+ */
+export class MockPortBinding implements BindingPortInterface {
+  readonly openOptions: Required<OpenOptions>
+  readonly port: MockPortInternal
+  private pendingRead: null | ((err: null | Error) => void)
+  lastWrite: null | Buffer
+  recording: Buffer
+  writeOperation: null | Promise<void>
+  isOpen: boolean
+  serialNumber?: string
+
+  constructor(port: MockPortInternal, openOptions: Required<OpenOptions>) {
+    this.port = port
+    this.openOptions = openOptions
+    this.pendingRead = null
+    this.isOpen = true
+    this.lastWrite = null
+    this.recording = Buffer.alloc(0)
+    this.writeOperation = null // in flight promise or null
+    this.serialNumber = port.info.serialNumber
+
+    if (port.readyData) {
+      const data = port.readyData
+      process.nextTick(() => {
+        if (this.isOpen) {
+          debug(this.serialNumber, 'emitting ready data')
+          this.emitData(data)
+        }
+      })
+    }
+  }
+
+  // Emit data on a mock port
+  emitData(data: Buffer | string) {
+    if (!this.isOpen || !this.port) {
+      throw new Error('Port must be open to pretend to receive data')
+    }
+    const bufferData = Buffer.isBuffer(data) ? data : Buffer.from(data)
+    debug(this.serialNumber, 'emitting data - pending read:', Boolean(this.pendingRead))
+    this.port.data = Buffer.concat([this.port.data, bufferData])
+    if (this.pendingRead) {
+      process.nextTick(this.pendingRead)
+      this.pendingRead = null
+    }
+  }
+
+  async close(): Promise<void> {
+    debug(this.serialNumber, 'close')
+    if (!this.isOpen) {
+      throw new Error('Port is not open')
+    }
+
+    const port = this.port
+    if (!port) {
+      throw new Error('already closed')
+    }
+
+    port.openOpt = undefined
+    // reset data on close
+    port.data = Buffer.alloc(0)
+    debug(this.serialNumber, 'port is closed')
+    this.serialNumber = undefined
+    this.isOpen = false
+    if (this.pendingRead) {
+      this.pendingRead(new CanceledError('port is closed'))
+    }
+  }
+
+  async read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+  ): Promise<{
+    buffer: Buffer
+    bytesRead: number
+  }> {
+    if (!Buffer.isBuffer(buffer)) {
+      throw new TypeError('"buffer" is not a Buffer')
+    }
+
+    if (typeof offset !== 'number' || isNaN(offset)) {
+      throw new TypeError(`"offset" is not an integer got "${isNaN(offset) ? 'NaN' : typeof offset}"`)
+    }
+
+    if (typeof length !== 'number' || isNaN(length)) {
+      throw new TypeError(`"length" is not an integer got "${isNaN(length) ? 'NaN' : typeof length}"`)
+    }
+
+    if (buffer.length < offset + length) {
+      throw new Error('buffer is too small')
+    }
+
+    if (!this.isOpen) {
+      throw new Error('Port is not open')
+    }
+
+    debug(this.serialNumber, 'read', length, 'bytes')
+    await resolveNextTick()
+    if (!this.isOpen || !this.port) {
+      throw new CanceledError('Read canceled')
+    }
+    if (this.port.data.length <= 0) {
+      return new Promise((resolve, reject) => {
+        this.pendingRead = err => {
+          if (err) {
+            return reject(err)
+          }
+          this.read(buffer, offset, length).then(resolve, reject)
+        }
+      })
+    }
+
+    const lengthToRead = this.port.maxReadSize > length ? length : this.port.maxReadSize
+
+    const data = this.port.data.slice(0, lengthToRead)
+    const bytesRead = data.copy(buffer, offset)
+    this.port.data = this.port.data.slice(lengthToRead)
+    debug(this.serialNumber, 'read', bytesRead, 'bytes')
+    return { bytesRead, buffer }
+  }
+
+  async write(buffer: Buffer): Promise<void> {
+    if (!Buffer.isBuffer(buffer)) {
+      throw new TypeError('"buffer" is not a Buffer')
+    }
+
+    if (!this.isOpen || !this.port) {
+      debug('write', 'error port is not open')
+      throw new Error('Port is not open')
+    }
+
+    debug(this.serialNumber, 'write', buffer.length, 'bytes')
+    if (this.writeOperation) {
+      throw new Error('Overlapping writes are not supported and should be queued by the serialport object')
+    }
+    this.writeOperation = (async () => {
+      await resolveNextTick()
+      if (!this.isOpen || !this.port) {
+        throw new Error('Write canceled')
+      }
+      const data = (this.lastWrite = Buffer.from(buffer)) // copy
+      if (this.port.record) {
+        this.recording = Buffer.concat([this.recording, data])
+      }
+      if (this.port.echo) {
+        process.nextTick(() => {
+          if (this.isOpen) {
+            this.emitData(data)
+          }
+        })
+      }
+      this.writeOperation = null
+      debug(this.serialNumber, 'writing finished')
+    })()
+    return this.writeOperation
+  }
+
+  async update(options: UpdateOptions): Promise<void> {
+    if (typeof options !== 'object') {
+      throw TypeError('"options" is not an object')
+    }
+
+    if (typeof options.baudRate !== 'number') {
+      throw new TypeError('"options.baudRate" is not a number')
+    }
+
+    debug(this.serialNumber, 'update')
+    if (!this.isOpen || !this.port) {
+      throw new Error('Port is not open')
+    }
+    await resolveNextTick()
+    if (this.port.openOpt) {
+      this.port.openOpt.baudRate = options.baudRate
+    }
+  }
+
+  async set(options: SetOptions): Promise<void> {
+    if (typeof options !== 'object') {
+      throw new TypeError('"options" is not an object')
+    }
+    debug(this.serialNumber, 'set')
+    if (!this.isOpen) {
+      throw new Error('Port is not open')
+    }
+    await resolveNextTick()
+  }
+
+  async get(): Promise<PortStatus> {
+    debug(this.serialNumber, 'get')
+    if (!this.isOpen) {
+      throw new Error('Port is not open')
+    }
+    await resolveNextTick()
+    return {
+      cts: true,
+      dsr: false,
+      dcd: false,
+    }
+  }
+
+  async getBaudRate(): Promise<{ baudRate: number }> {
+    debug(this.serialNumber, 'getBaudRate')
+    if (!this.isOpen || !this.port) {
+      throw new Error('Port is not open')
+    }
+    await resolveNextTick()
+    if (!this.port.openOpt?.baudRate) {
+      throw new Error('Internal Error')
+    }
+    return {
+      baudRate: this.port.openOpt.baudRate,
+    }
+  }
+
+  async flush(): Promise<void> {
+    debug(this.serialNumber, 'flush')
+    if (!this.isOpen || !this.port) {
+      throw new Error('Port is not open')
+    }
+    await resolveNextTick()
+    this.port.data = Buffer.alloc(0)
+  }
+
+  async drain(): Promise<void> {
+    debug(this.serialNumber, 'drain')
+    if (!this.isOpen) {
+      throw new Error('Port is not open')
+    }
+    await this.writeOperation
+    await resolveNextTick()
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@reconbot/typescript-library-template",
       "version": "0.0.0-development",
       "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "^1.2.1",
+        "debug": "^4.3.3"
+      },
       "devDependencies": {
         "@microsoft/api-extractor": "7.19.4",
         "@types/chai": "4.3.0",
@@ -643,6 +647,14 @@
       },
       "peerDependencies": {
         "semantic-release": ">=18.0.0-beta.1"
+      }
+    },
+    "node_modules/@serialport/bindings-interface": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.1.tgz",
+      "integrity": "sha512-63Dyqz2gtryRDDckFusOYqLYhR3Hq/M4sEdbF9i/VsvDb6T+tNVgoAKUZ+FMrXXKnCSu+hYbk+MTc0XQANszxw==",
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -1533,7 +1545,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1549,8 +1560,7 @@
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
@@ -8619,6 +8629,11 @@
         "read-pkg-up": "^7.0.0"
       }
     },
+    "@serialport/bindings-interface": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.1.tgz",
+      "integrity": "sha512-63Dyqz2gtryRDDckFusOYqLYhR3Hq/M4sEdbF9i/VsvDb6T+tNVgoAKUZ+FMrXXKnCSu+hYbk+MTc0XQANszxw=="
+    },
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -9265,7 +9280,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       },
@@ -9273,8 +9287,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@reconbot/typescript-library-template",
+  "name": "@serialport/binding-mock",
   "version": "0.0.0-development",
-  "description": "Rollup your code and types for publishing",
+  "description": "The mock serialport bindings",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -9,10 +9,10 @@
     "default": "./dist/index-esm.mjs"
   },
   "engines": {
-    "node": "^12.22 || ^14.13 || >=16"
+    "node": ">=12.0.0"
   },
-  "repository": "git@github.com:reconbot/typescript-library-template.git",
-  "homepage": "https://github.com/reconbot/typescript-library-template",
+  "repository": "git@github.com:serialport/binding-mock.git",
+  "homepage": "https://github.com/serialport/binding-mock",
   "scripts": {
     "test": "mocha",
     "lint": "tsc && eslint lib/**/*.ts",
@@ -23,7 +23,8 @@
     "semantic-release": "semantic-release"
   },
   "keywords": [
-    "typescript-library-template"
+    "serialport-binding",
+    "debug"
   ],
   "license": "MIT",
   "devDependencies": {
@@ -49,5 +50,9 @@
       "esbuild-register"
     ],
     "spec": "lib/**/*-test.ts"
+  },
+  "dependencies": {
+    "@serialport/bindings-interface": "^1.2.1",
+    "debug": "^4.3.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,5 +9,5 @@ export default {
     { format: 'esm', file: './dist/index-esm.mjs' },
     { format: 'cjs', file: './dist/index.js' },
   ],
-  external: [],
+  external: ['debug', '@serialport/bindings-interface'],
 }


### PR DESCRIPTION
Move the mock binding code from the monorepo - where it is now unfortunately has it part of a circular dependency with `bindings-cpp` and `binding-interface`. To update the interface, you need to publish the interface, update the monorepo's `binding-mock` but not any other package, publish that (difficult or impossible because of how lerna works), update `bindings-cpp` and then update the rest of the packages in the monorepo.

With this move to a new repository;
- update `bindings-interface`
- update `bindings-mock`
- update `bindings-cpp`
- update the serialport monorepo

This is still way to many steps but at least it's possible.

You might be asking why we have a `bindings-interface` package at all? Because every binding that the monorepo supports needs to impliment the same bindings interface.

Why does `bindings-cpp` use `bindings-mock`? This is to ensure we have the same test suite passing for both bindings. It's not ideal but I'm not sure how we might separate it out. It's a holdover from when they were in the same monorepo.