### PR TITLE
Adds types to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
     "default": "./dist/index-esm.mjs"
   },


### PR DESCRIPTION
Newer TypeScript moduleResolution values require the types to be annotated in the `exports` section of package.json.

Without this fix, `tsc` throws an error saying the package is missing types. 